### PR TITLE
Cleaning up copy task, vendor/foundation.min.js is a vendor

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -62,16 +62,10 @@ module.exports = function(grunt) {
 				}, {
 					expand: true,
 					flatten: true,
-					src: ['app/bower_components/jquery/jquery.min.js', 'app/bower_components/modernizr/modernizr.js'],
+					src: ['app/bower_components/jquery/jquery.min.js', 'app/bower_components/modernizr/modernizr.js', 'app/bower_components/foundation/js/foundation.min.js'],
 					dest: 'dist/<%= CommonDirName %>/js/vendor/',
 					filter: 'isFile'
-				}, {
-					expand: true,
-					flatten: true,
-					src: ['app/bower_components/foundation/js/foundation.min.js'],
-					dest: 'dist/<%= CommonDirName %>/js/foundation/',
-					filter: 'isFile'
-				}<% if (fontAwesome) { %> , {
+				}, <% if (fontAwesome) { %> , {
 					expand: true,
 					flatten: true,
 					src: ['app/bower_components/font-awesome/fonts/**'],


### PR DESCRIPTION
Foundation's javascript is no different than jquery.min.js and modernizr.min.js in the vendor/ folder; this pull request modifies the Gruntfile.js removing the extra copy task and adding foundation.min.js to the previous task.
