### PR TITLE
Replaces duplicate `description` field in package.json

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -2,7 +2,7 @@
   "name": "zf5_project",
   "description": "",
   "version": "0.0.1",
-  "description": "",
+  "license": "",
   "homepage": "",
   "author": {
     "name": "",


### PR DESCRIPTION
Replaces duplicate `description` field with a `license` field.

This closes #45.